### PR TITLE
Fix heroku backup command

### DIFF
--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -27,7 +27,7 @@ chmod +x ./awscli-bundle/install
 APP_DB_COMBO="$APP-$DATABASE"
 BACKUP_FILE_NAME="$(date +"%Y-%m-%d-%H-%M")-$APP-$DATABASE.dump"
 
-/app/vendor/heroku-toolbelt/bin/heroku pg:backups capture $DATABASE --app $APP
+/app/vendor/heroku-toolbelt/bin/heroku pg:backups:capture $DATABASE --app $APP
 curl -o $BACKUP_FILE_NAME `/app/vendor/heroku-toolbelt/bin/heroku pg:backups public-url --app $APP`
 gzip $BACKUP_FILE_NAME
 /tmp/aws/bin/aws s3 cp $BACKUP_FILE_NAME.gz s3://$S3_BUCKET_PATH/$APP/$DATABASE/$BACKUP_FILE_NAME.gz
@@ -38,4 +38,3 @@ if [ -n "$ALIVE_DB_URL" ]; then
 fi
 
 echo "backup $BACKUP_FILE_NAME complete"
-


### PR DESCRIPTION
The command to capture a heroku backup is now`pg:backups:capture` ([reference](https://devcenter.heroku.com/articles/heroku-postgres-backups#creating-a-backup)).